### PR TITLE
Fix: Display in Safari

### DIFF
--- a/packages/forms/resources/views/components/field-wrapper/label.blade.php
+++ b/packages/forms/resources/views/components/field-wrapper/label.blade.php
@@ -20,7 +20,8 @@
         ])
     >
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $slot }}@if ($required)<span class="whitespace-nowrap">
+        {{ $slot }}@if ($required)
+            <span class="whitespace-nowrap">
                 <sup
                     @class([
                         'text-danger-700 font-medium',


### PR DESCRIPTION
For some weirdly reason, when you have a label containing an hyphen character, the label is displayed with a carrier return in Safari.
This will prevent this UI behaviour.